### PR TITLE
Fix: filter control bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "fabric": "^6.0.0-beta7",
+        "fabric": "^6.0.0-beta8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
@@ -2899,9 +2899,9 @@
       }
     },
     "node_modules/fabric": {
-      "version": "6.0.0-beta7",
-      "resolved": "https://registry.npmjs.org/fabric/-/fabric-6.0.0-beta7.tgz",
-      "integrity": "sha512-1SPn71J3Qp7SU9JbKmizc3xEwrUa7DJVq2qyzYyczd/KjuzM9u9/cW40zlCz+0Mu5uE0vCQ0tUsGkYLsecsXzQ==",
+      "version": "6.0.0-beta8",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-6.0.0-beta8.tgz",
+      "integrity": "sha512-cVyfIcLfGhzWI66955fI2QenEer3atMCDWDAKDoDAgImGhB1uSul/cCeOchjaXRer/qyiuIf8N27xT5ar7Vsdg==",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -8329,9 +8329,9 @@
       "devOptional": true
     },
     "fabric": {
-      "version": "6.0.0-beta7",
-      "resolved": "https://registry.npmjs.org/fabric/-/fabric-6.0.0-beta7.tgz",
-      "integrity": "sha512-1SPn71J3Qp7SU9JbKmizc3xEwrUa7DJVq2qyzYyczd/KjuzM9u9/cW40zlCz+0Mu5uE0vCQ0tUsGkYLsecsXzQ==",
+      "version": "6.0.0-beta8",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-6.0.0-beta8.tgz",
+      "integrity": "sha512-cVyfIcLfGhzWI66955fI2QenEer3atMCDWDAKDoDAgImGhB1uSul/cCeOchjaXRer/qyiuIf8N27xT5ar7Vsdg==",
       "requires": {
         "canvas": "^2.8.0",
         "jsdom": "^20.0.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "fabric": "^6.0.0-beta7",
+    "fabric": "^6.0.0-beta8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",

--- a/src/components/FilterControl.tsx
+++ b/src/components/FilterControl.tsx
@@ -44,6 +44,7 @@ export default function FilterControl(props: FilterControlType) {
     const image = canvas.getActiveObject() as fabric.Image
     const parsedImage: fabric.Image = await image.toJSON()
     const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => f.type === id)
+    console.log(filterIndex)
 
     if (filterIndex !== -1) {
       // Tweak existing filter

--- a/src/components/FilterControl.tsx
+++ b/src/components/FilterControl.tsx
@@ -43,8 +43,9 @@ export default function FilterControl(props: FilterControlType) {
 
     const image = canvas.getActiveObject() as fabric.Image
     const parsedImage: fabric.Image = await image.toJSON()
-    const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => f.type === id)
-    console.log(filterIndex)
+    const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => f.type.toLowerCase() === filterTypeLower)
+    console.log(parsedImage.filters)
+    console.log(id)
 
     if (filterIndex !== -1) {
       // Tweak existing filter

--- a/src/components/FilterControl.tsx
+++ b/src/components/FilterControl.tsx
@@ -38,11 +38,11 @@ export default function FilterControl(props: FilterControlType) {
   const computePercentage = () => Math.round(((rangeValue - min) / (max - min)) * 100)
 
   // Add or update the image filter when the range value changes
-  const addFilter = (filterValue: number) => {
+  const addFilter = async (filterValue: number) => {
     if (!canvas) return
 
     const image = canvas.getActiveObject() as fabric.Image
-    const parsedImage: fabric.Image = image.toJSON()
+    const parsedImage: fabric.Image = await image.toJSON()
     const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => f.type === id)
 
     if (filterIndex !== -1) {
@@ -56,19 +56,19 @@ export default function FilterControl(props: FilterControlType) {
       image.filters.push(newFilter(filterValue))
     }
 
-    image.applyFilters()
+    image.applyFilters(image.filters)
     canvas.renderAll()
   }
 
   // Update the filter value when the range value changes
-  const setValue = (value: string) => {
+  const setValue = async (value: string) => {
     if (selectedImageIndex === null) {
       toast("Please select an image to apply filter", { id: "no-image" })
       return
     }
 
     // Start adding the actual filter
-    addFilter(parseFloat(value))
+    await addFilter(parseFloat(value))
 
     // Set selectedImage value in redux, it will take care of the rest
     dispatch(setImageFilterValue({

--- a/src/components/FilterControl.tsx
+++ b/src/components/FilterControl.tsx
@@ -43,9 +43,7 @@ export default function FilterControl(props: FilterControlType) {
 
     const image = canvas.getActiveObject() as fabric.Image
     const parsedImage: fabric.Image = await image.toJSON()
-    const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => f.type.toLowerCase() === filterTypeLower)
-    console.log(parsedImage.filters)
-    console.log(id)
+    const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => filterTypeLower in f)
 
     if (filterIndex !== -1) {
       // Tweak existing filter


### PR DESCRIPTION
# Bug report
Fabric.js produces different filter `type` in production for unknown reason.

`canvas.getActiveObject().toJSON().filters` in development:
```
[
  {type: 'Noise', noise: 26},
  {type: 'Brightness', brightness: 0.208},
  {type: 'Contrast', contrast: 0.226},
]
```

`canvas.getActiveObject().toJSON().filters` in production:
```
[
  {type: 'bu', noise: 61},
  {type: 'Cu', contrast: 0.454},
]
```

# Solution
- Instead of checking `type` property, check for the presence of a specific filter property in filters object.
```
const filterIndex = parsedImage.filters.findIndex((f: { type: string }) => filterTypeLower in f)
```